### PR TITLE
Off-by-one Error in Data Shards (and Empty Shards)

### DIFF
--- a/data/dataset_prep.py
+++ b/data/dataset_prep.py
@@ -74,7 +74,7 @@ def shard_dataset(src_dir, size_dict, dest_dir, split="test", percent=100, shard
             sample["cameras"] = src_zip.read(f"{dir_name}/cameras.npz")
             tar_sink.write(sample)
             sample_no += 1
-            if sample_no == limit:
+            if (sample_no == limit) and (shard_idx < (shard_cnt - 1)):
                 sample_no = 0
                 shard_idx += 1
                 tar_sink = wds.TarWriter(


### PR DESCRIPTION
This PR aims to improve the existing logic in data sharding of view-fusion work.

The existing logic leads to an off-by-one error in the number of shards, i.e.
The data sharding command of `python data/dataset_prep.py—sc 4` results in 5 shards, which might not be the user's intention. Also, the additional shards are empty in some cases, leading to errors in the distributed training process.

With this new logic, all shards except one have the same number of samples. For example

split = “train”
split_dict_values_sum = 30661
shard_count = 4

train_shard_00, train_shard_01, train_shard_02 = 7665 <br>
train_shard_03 = 7666